### PR TITLE
POM bugfixes and other tweaks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: "maven"
 apply plugin: "signing"
 
 group = "org.opensextant"
-version = "2.0.1"
+version = "2.0.1-SNAPSHOT"
 sourceCompatibility = 1.6
 
 // Publishing locations


### PR DESCRIPTION
While trying to deploy a GISCore snapshot internally to support our other projects.

First of all, the code needs to be compiled for Java 6 because some of our clients only have that available.
More problematically, the Ivy-style dependencies are not being converted correctly when generating the POM.  This results in dependencies like this:

``` xml
<dependency>
  <groupId>org.opensextant</groupId>
  <artifactId>geodesy</artifactId>
  <version>2.0.+</version>
  <scope>compile</scope>
</dependency>
```

Maven doesn't understand version numbers like this and tries to download org.opensextant:geodesy:2.0.+ and then complains when it isn't available.
I also switched the version number to 2.0.1-SNAPSHOT so that local installs and interim deployments aren't using the release version.  Those will cause problems when 2.0.1 is released for real.  I'd recommend bumping to 2.0.2 for the next official release.
Finally, as an enhancement I added input and output declarations to the packageLibrary task so that they would only be rerun when it's actually necessary.
